### PR TITLE
Introduce controller selection

### DIFF
--- a/config/exomy.yaml.template
+++ b/config/exomy.yaml.template
@@ -43,3 +43,6 @@ drive_pwm_neutral: 307
 
 # PWW range around driving neutral position
 drive_pwm_range: 100
+
+# Select connected controller (possible options: "logitech-F710" or "xbox-one")
+controller: "logitech-F710"

--- a/gui/index.html
+++ b/gui/index.html
@@ -48,7 +48,7 @@
 
       self.manager.on('move', function (event, nipple) {
         var max_distance = 75;
-        var x = -Math.cos(nipple.angle.radian) * nipple.distance / max_distance;
+        var x = Math.cos(nipple.angle.radian) * nipple.distance / max_distance;
         var y = Math.sin(nipple.angle.radian) * nipple.distance / max_distance;
         axes = [x, y, 0, 0, 0, 0]
 
@@ -95,6 +95,9 @@
 
     joy_event = function () {
       var joy = new ROSLIB.Message({
+        header: {
+			    frame_id: "webgui"
+		    },
         axes: axes,
         buttons: buttons
       });

--- a/src/joystick_parser_node.py
+++ b/src/joystick_parser_node.py
@@ -4,6 +4,7 @@ from sensor_msgs.msg import Joy
 from exomy.msg import RoverCommand
 from locomotion_modes import LocomotionMode
 import math
+import time
 
 # Define locomotion modes
 global locomotion_mode
@@ -20,7 +21,7 @@ def callback(data):
 
     rover_cmd = RoverCommand()
 
-    # Function map for the Logitech F710 joystick
+    # Function map for joystick
     # Button on pad | function
     # --------------|----------------------
     # A             | Ackermann mode
@@ -29,35 +30,100 @@ def callback(data):
     # Left Stick    | Control speed and direction
     # START Button  | Enable and disable motors
 
+    # More info on mapping: https://wiki.ros.org/joy
+    if data.header.frame_id == "webgui":
+        # Logitech WebGUI
+        controller_funtion_map = {
+            "x_axis": 0,
+            "y_axis": 1,
+            "invert_x_axis": True,
+            "X_button": 0,
+            "Y_button": 3,
+            "A_button": 1,
+            "B_button": 2,
+            "start_button": 9,
+            "select_button": 8,
+            "sensitivity": 0.15
+        }
+    elif rospy.get_param("controller") == "logitech-F710": 
+        # Logitech F710 joystick
+        controller_funtion_map = {
+            "x_axis": 0,
+            "y_axis": 1,
+            "invert_x_axis": True,
+            "X_button": 0,
+            "Y_button": 3,
+            "A_button": 1,
+            "B_button": 2,
+            "start_button": 9,
+            "select_button": 8,
+            "sensitivity": 0.1
+        }
+    elif rospy.get_param("controller") == "xbox-one": 
+        #X-Box One controller
+        controller_funtion_map = {
+            "x_axis": 0,
+            "y_axis": 1,
+            "invert_x_axis": True,
+            "X_button": 2,
+            "Y_button": 3,
+            "A_button": 0,
+            "B_button": 1,
+            "start_button": 7,
+            "select_button": 6,
+            "sensitivity": 0.11
+        }
+    else:
+        rospy.logerr("No controller identified. Using fallback.")
+        controller_funtion_map = {
+            "x_axis": 0,
+            "y_axis": 1,
+            "invert_x_axis": True,
+            "X_button": 0,
+            "Y_button": 3,
+            "A_button": 1,
+            "B_button": 2,
+            "start_button": 9,
+            "select_button": 8,
+            "sensitivity": 0.0
+        }
+   
     # Reading out joystick data
     y = data.axes[1]
     x = data.axes[0]
 
+    if controller_funtion_map["invert_x_axis"] == True:
+        x = x * -1
+
     # Reading out button data to set locomotion mode
     # X Button
-    if (data.buttons[0] == 1):
+    if (data.buttons[controller_funtion_map["X_button"]] == 1):
         locomotion_mode = LocomotionMode.POINT_TURN.value
     # A Button
-    if (data.buttons[1] == 1):
+    if (data.buttons[controller_funtion_map["A_button"]] == 1):
         locomotion_mode = LocomotionMode.ACKERMANN.value
     # B Button
-    if (data.buttons[2] == 1):
+    if (data.buttons[controller_funtion_map["B_button"]] == 1):
         pass
     # Y Button
-    if (data.buttons[3] == 1):
+    if (data.buttons[controller_funtion_map["Y_button"]] == 1):
         locomotion_mode = LocomotionMode.CRABBING.value
 
     rover_cmd.locomotion_mode = locomotion_mode
 
     # Enable and disable motors
     # START Button
-    if (data.buttons[9] == 1):
+    if (data.buttons[controller_funtion_map["start_button"]] == 1):
         if motors_enabled is True:
             motors_enabled = False
             rospy.loginfo("Motors disabled!")
+            # Set a sleep timer, if not a button movement could be triggered falsely
+            time.sleep(0.5)
         elif motors_enabled is False:
             motors_enabled = True
             rospy.loginfo("Motors enabled!")
+            # Set a sleep timer, if not a button movement could be triggered falsely
+            time.sleep(0.5)
         else:
             rospy.logerr(
                 "Exceptional value for [motors_enabled] = {}".format(motors_enabled))
@@ -66,7 +132,13 @@ def callback(data):
     rover_cmd.motors_enabled = motors_enabled
 
     # The velocity is decoded as value between 0...100
-    rover_cmd.vel = 100 * min(math.sqrt(x*x + y*y), 1.0)
+    # Sensitivity defines an area in the center, where no steering or speed commands are send to allow for lower speeds without loosing directions
+    # Similar to "joy_node"-"deadzone"-parameter. The parameter is not touched, as every controller has its own sensitivity
+    rover_cmd.vel = min(math.sqrt(x*x + y*y), 1.0)
+    if rover_cmd.vel < controller_funtion_map["sensitivity"]:
+        rover_cmd.vel = 0
+    else:
+        rover_cmd.vel = (rover_cmd.vel - controller_funtion_map["sensitivity"]) * (1 / (1 - controller_funtion_map["sensitivity"])) * 100
 
     # The steering is described as an angle between -180...180
     # Which describe the joystick position as follows:


### PR DESCRIPTION
Introduce an option to select a hardware controller.

Updates:
- Update of config file -> needs to be added manually to old files
- index.html: to identify the webgui clearly as a controller; remove invert of axis. This is now done in the joy_stick_parser.
- joystick_parser_node: config dicts for different controllers (currently Logitech F710 and X-Box One)

Introduced sensitivity on controller to allow for a certain threshold. Tests have shown, that even all sticks are released, a controller might send a very low value. The joy_node has a similar "deadzone"-parameter, but this parameter is not used on purpose to allow for different sensitivity based on different controlling methods.